### PR TITLE
README.ja中のgitからのインストール方法についての追記

### DIFF
--- a/README.ja
+++ b/README.ja
@@ -68,6 +68,8 @@ GitHubの "clear-code/pikzie
 git::
 
   % git clone https://github.com/clear-code/pikzie.git
+  % cd pikzie
+  % sudo python setup.py install
 
 使い方
 ======


### PR DESCRIPTION
README.jaに記載のgitからのpikzieインストールの方法について追記．クローンした後のインストール方法が自明でなかったため．
