### PR TITLE
README.ja中の文章段落の順番を変更

### DIFF
--- a/README
+++ b/README
@@ -86,6 +86,24 @@ We assume that you have the following directory structure::
               |
 	      +- ...
 
+Template
+--------
+
+Here is a template of a test case::
+
+  import pikzie
+  import test_target_module
+  
+  class TestYourModule(pikzie.TestCase):
+      def setup(self):
+	  self.setup_called = True
+  
+      def teardown(self):
+	  self.setup_called = False
+  
+      def test_condition(self): # starts with "test_"
+          self.assert_true(self.setup_called)
+
 test/run-test.py is the following::
 
   #!/usr/bin/env python
@@ -116,95 +134,6 @@ You can execute by command below::
 or::
   % python test/run_test.py
 
-Options
--------
-
---version               shows its own version and exits.
-
--pPATTERN, --test-file-name-pattern=PATTERN collects test
-                                            files that
-                                            matches with the
-                                            specified glob
-                                            pattern.
-
-					    Default: test/test_*.py
-
--nTEST_NAME, --name=TEST_NAME  runs tests that are matched
-                               with TEST_NAME. If TEST_NAME
-                               is surrounded by "/"
-                               (e.g. /test\_/), TEST_NAME is
-                               handled as regular
-                               expression.
-
-			       This option can be specified
-                               n times. In the case, Pikzie
-                               runs tests that are matched
-                               with any TEST_NAME.
-
--tTEST_CASE_NAME, --test-case=TEST_CASE_NAME  runs test
-                                              cases that are
-                                              matched with
-                                              TEST_CASE_NAME.
-					      If
-                                              TEST_CASE_NAME
-                                              is surrounded
-                                              by "/"
-                                              (e.g. /TestMyLib/),
-                                              TEST_CASE_NAME
-                                              is handled as
-                                              regular
-                                              expression.
-
-					      This option
-					      can be
-					      specified n
-					      times. In the
-					      case, Pikzie
-					      runs test
-					      cases that are
-					      matched with
-					      any
-					      TEST_CASE_NAME.
-
---xml-report=FILE         outputs test result in XML format
-                          to FILE.
-
---priority                selects tests to run according to
-                          their priority. If a test is not
-                          passed in the previous test, the
-                          test is ran.
-
---no-priority             runs all tests regardless of their
-                          priority. (default)
-
--vLEVEL, --verbose=LEVEL  specifies verbose level. LEVEL is
-                          one of [s|silent|n|normal|v|verbose].
-
-			  This option is only for console
-			  UI. (There is only console UI at
-			  present.)
-
--cMODE, --color=MODE      specifies whether colorize output
-                          or not. MODE is one of
-                          [yes|true|no|false|auto]. If 'yes'
-                          or 'true' is specified, colorized
-                          output by escape sequence is used.
-			  If 'no' or 'false' is specified,
-                          colorized output is never used. If 'auto'
-			  or the option is omitted,
-                          colorized output is used if available.
-
-			  This option is only for console
-			  UI. (There is only console UI at
-			  present.)
-
---color-scheme=SCHEME     specifies whether color scheme is
-                          used for output. SCHEME is one of
-                          [default].
-
-			  This option is only for console
-			  UI. (There is only console UI at
-			  present.)
 
 Test result
 ===========
@@ -381,6 +310,96 @@ structure::
 References
 ==========
 
+Options
+-------
+
+--version               shows its own version and exits.
+
+-pPATTERN, --test-file-name-pattern=PATTERN collects test
+                                            files that
+                                            matches with the
+                                            specified glob
+                                            pattern.
+
+					    Default: test/test_*.py
+
+-nTEST_NAME, --name=TEST_NAME  runs tests that are matched
+                               with TEST_NAME. If TEST_NAME
+                               is surrounded by "/"
+                               (e.g. /test\_/), TEST_NAME is
+                               handled as regular
+                               expression.
+
+			       This option can be specified
+                               n times. In the case, Pikzie
+                               runs tests that are matched
+                               with any TEST_NAME.
+
+-tTEST_CASE_NAME, --test-case=TEST_CASE_NAME  runs test
+                                              cases that are
+                                              matched with
+                                              TEST_CASE_NAME.
+					      If
+                                              TEST_CASE_NAME
+                                              is surrounded
+                                              by "/"
+                                              (e.g. /TestMyLib/),
+                                              TEST_CASE_NAME
+                                              is handled as
+                                              regular
+                                              expression.
+
+					      This option
+					      can be
+					      specified n
+					      times. In the
+					      case, Pikzie
+					      runs test
+					      cases that are
+					      matched with
+					      any
+					      TEST_CASE_NAME.
+
+--xml-report=FILE         outputs test result in XML format
+                          to FILE.
+
+--priority                selects tests to run according to
+                          their priority. If a test is not
+                          passed in the previous test, the
+                          test is ran.
+
+--no-priority             runs all tests regardless of their
+                          priority. (default)
+
+-vLEVEL, --verbose=LEVEL  specifies verbose level. LEVEL is
+                          one of [s|silent|n|normal|v|verbose].
+
+			  This option is only for console
+			  UI. (There is only console UI at
+			  present.)
+
+-cMODE, --color=MODE      specifies whether colorize output
+                          or not. MODE is one of
+                          [yes|true|no|false|auto]. If 'yes'
+                          or 'true' is specified, colorized
+                          output by escape sequence is used.
+			  If 'no' or 'false' is specified,
+                          colorized output is never used. If 'auto'
+			  or the option is omitted,
+                          colorized output is used if available.
+
+			  This option is only for console
+			  UI. (There is only console UI at
+			  present.)
+
+--color-scheme=SCHEME     specifies whether color scheme is
+                          used for output. SCHEME is one of
+                          [default].
+
+			  This option is only for console
+			  UI. (There is only console UI at
+			  present.)
+
 Assertions
 ----------
 
@@ -437,23 +456,6 @@ pikzie.priority(priority)
   never
     never run the test.
 
-Template
---------
-
-Here is a template of a test case::
-
-  import pikzie
-  import test_target_module
-  
-  class TestYourModule(pikzie.TestCase):
-      def setup(self):
-	  self.setup_called = True
-  
-      def teardown(self):
-	  self.setup_called = False
-  
-      def test_condition(self): # starts with "test_"
-          self.assert_true(self.setup_called)
 
 Thanks
 ------

--- a/README.ja
+++ b/README.ja
@@ -86,6 +86,27 @@ git::
               |
 	      +- ...
 
+
+雛型
+----
+
+テストの雛型は以下のようになります。::
+
+  import pikzie
+  import テスト対象のモジュール
+  
+  class TestYourModule(pikzie.TestCase):
+      def setup(self):
+          # 初期化用コード
+	  self.setup_called = True
+  
+      def teardown(self):
+          # 後片付け用コード
+	  self.setup_called = False
+  
+      def test_condition(self): # "test_"から始める
+          self.assert_true(self.setup_called)
+
 test/run-test.pyは以下の通りです。::
 
   #!/usr/bin/env python
@@ -116,90 +137,6 @@ test/run-test.pyは以下の通りです。::
 あるいは::
   % python test/run_test.py
 
-オプション
-==========
-
---version                バージョンを表示して終了します。
-
--pPATTERN, --test-file-name-pattern=PATTERN テストファイル名
-                                            にマッチするグロ
-                                            ブパターンを指定
-                                            します。
-
-					    デフォルトは
-					    test/test_*.pyで
-					    す。
-
--nTEST_NAME, --name=TEST_NAME  TEST_NAMEにマッチしたテストを実
-                               行します。もし、TEST_NAMEが
-                               "/"で囲まれていた場合は（例:
-                               /test\_/）正規表現として扱いま
-                               す。
-
-			       このオプションは何度でも指定で
-                               き、その場合は、どれかのパター
-                               ンにマッチしたテストすべてが実
-                               行されます。
-
--tTEST_CASE_NAME, --test-case=TEST_CASE_NAME  TEST_CASE_NAME
-                                              にマッチしたテ
-                                              ストケースを実
-                                              行します。もし、
-                                              TEST_CASE_NAME
-                                              が"/"で囲まれて
-                                              いた場合は（例:
-                                              /TestMyLib/）正
-                                              規表現として扱
-                                              います。
-
-					      このオプション
-                                              は何度でも指定
-                                              でき、その場合
-                                              は、どれかのパ
-                                              ターンにマッチ
-                                              したテストケー
-                                              スすべてが実行
-                                              されます。
-
---xml-report=FILE         テスト結果をXML形式でFILEに出力し
-                          ます。
-
---priority                優先度に応じて実行するテストを選択
-                          します。優先度が低いテストでも、前
-                          回のテストでパスしていないテストは
-                          実行します。
-
---no-priority             優先度に関係なく全てのテストを実行
-                          します。（デフォルト）
-
--vLEVEL, --verbose=LEVEL  出力の詳細さを指定します。LEVELは
-                          [s|silent|n|normal|v|verbose]のう
-			  ちのどれかです。
-
-			  このオプションはコンソールUIを使用
-			  する場合だけ有効です。（現在はコン
-			  ソールUIしかありません。）
-
--cMODE, --color=MODE      出力を色付けするかどうかを指定しま
-                          す。MODEには[yes|true|no|false|auto]の
-                          どれかを指定します。yesまたはtrue
-                          が指定された場合はエスケープシーケ
-                          ンスで色付けして出力します。
-                          noまたはfalseが指定された場合は色付
-                          けしません。autoあるいは値が省略さ
-                          れた時は、可能なら色付けをします。
-
-			  このオプションはコンソールUIを使用
-                          する場合だけ有効です。（現在はコン
-                          ソールUIしかありません。）
-
---color-scheme=SCHEME     出力時にどの色を使うかを指定します。
-                          SCHEMEには[default]のどれかを指定
-                          します。
-
-			  このオプションはコンソールUIを使用
-                          する場合だけ有効です。（現在はコン
-                          ソールUIしかありません。）
 
 テスト結果
 ==========
@@ -378,6 +315,90 @@ XML出力
 リファレンス
 ============
 
+オプション
+==========
+
+--version                バージョンを表示して終了します。
+
+-pPATTERN, --test-file-name-pattern=PATTERN テストファイル名
+                                            にマッチするグロ
+                                            ブパターンを指定
+                                            します。
+
+					    デフォルトは
+					    test/test_*.pyで
+					    す。
+
+-nTEST_NAME, --name=TEST_NAME  TEST_NAMEにマッチしたテストを実
+                               行します。もし、TEST_NAMEが
+                               "/"で囲まれていた場合は（例:
+                               /test\_/）正規表現として扱いま
+                               す。
+
+			       このオプションは何度でも指定で
+                               き、その場合は、どれかのパター
+                               ンにマッチしたテストすべてが実
+                               行されます。
+
+-tTEST_CASE_NAME, --test-case=TEST_CASE_NAME  TEST_CASE_NAME
+                                              にマッチしたテ
+                                              ストケースを実
+                                              行します。もし、
+                                              TEST_CASE_NAME
+                                              が"/"で囲まれて
+                                              いた場合は（例:
+                                              /TestMyLib/）正
+                                              規表現として扱
+                                              います。
+
+					      このオプション
+                                              は何度でも指定
+                                              でき、その場合
+                                              は、どれかのパ
+                                              ターンにマッチ
+                                              したテストケー
+                                              スすべてが実行
+                                              されます。
+
+--xml-report=FILE         テスト結果をXML形式でFILEに出力し
+                          ます。
+
+--priority                優先度に応じて実行するテストを選択
+                          します。優先度が低いテストでも、前
+                          回のテストでパスしていないテストは
+                          実行します。
+
+--no-priority             優先度に関係なく全てのテストを実行
+                          します。（デフォルト）
+
+-vLEVEL, --verbose=LEVEL  出力の詳細さを指定します。LEVELは
+                          [s|silent|n|normal|v|verbose]のう
+			  ちのどれかです。
+
+			  このオプションはコンソールUIを使用
+			  する場合だけ有効です。（現在はコン
+			  ソールUIしかありません。）
+
+-cMODE, --color=MODE      出力を色付けするかどうかを指定しま
+                          す。MODEには[yes|true|no|false|auto]の
+                          どれかを指定します。yesまたはtrue
+                          が指定された場合はエスケープシーケ
+                          ンスで色付けして出力します。
+                          noまたはfalseが指定された場合は色付
+                          けしません。autoあるいは値が省略さ
+                          れた時は、可能なら色付けをします。
+
+			  このオプションはコンソールUIを使用
+                          する場合だけ有効です。（現在はコン
+                          ソールUIしかありません。）
+
+--color-scheme=SCHEME     出力時にどの色を使うかを指定します。
+                          SCHEMEには[default]のどれかを指定
+                          します。
+
+			  このオプションはコンソールUIを使用
+                          する場合だけ有効です。（現在はコン
+                          ソールUIしかありません。）
 表明
 ----
 
@@ -433,25 +454,6 @@ pikzie.priority(priority)
   never
     実行しない。
 
-雛型
-----
-
-テストの雛型は以下のようになります。::
-
-  import pikzie
-  import テスト対象のモジュール
-  
-  class TestYourModule(pikzie.TestCase):
-      def setup(self):
-          # 初期化用コード
-	  self.setup_called = True
-  
-      def teardown(self):
-          # 後片付け用コード
-	  self.setup_called = False
-  
-      def test_condition(self): # "test_"から始める
-          self.assert_true(self.setup_called)
 
 謝辞
 ----


### PR DESCRIPTION
README.ja中のオプションに関する説明をレファレンス部分に移動．また，my_moduleのひな形例に関する記述をテストの実行例に関する説明部分に移動．ひな形に関する記述が最後に位置しているとつながりが理解し難いためこのような変更をしました．
