### PR TITLE
Suppress auto_test_run() when installing via pip.

### DIFF
--- a/lib/pikzie/tester.py
+++ b/lib/pikzie/tester.py
@@ -103,6 +103,7 @@ auto_test_run_reject_pattern = \
 def auto_test_run():
     if Tester.ran: return
     if not sys.argv[0]: return
+    if sys.argv[0] == '-c': return
     if re.search(auto_test_run_reject_pattern, sys.argv[0]): return
     sys.exit(Tester(target_modules=['__main__']).run())
 


### PR DESCRIPTION
This fixes the "pip install" failure due to the auto-exec feature of tester.py.
### What's the problem?

Currently pip runs setup.py in a special way that the setuptools
module gets always imported (namely, running a customized one-liner
script with Python -c option).

In this case, sys.argv[0] will become '-c' (see the documentation
on sys.argv) and this also needs to be handled by auto_test_run().
### Reference Links
- https://github.com/pypa/pip/blob/master/pip/req/req_install.py#L852
- https://docs.python.org/2/library/sys.html#sys.argv
