### PR TITLE
Python 3: replace file() with open().

### DIFF
--- a/lib/pikzie/report.py
+++ b/lib/pikzie/report.py
@@ -19,7 +19,7 @@ class XML(object):
     def __init__(self, output):
         self.file = isinstance(output, str)
         if self.file:
-            output = file(output, "w")
+            output = open(output, "w")
         self.output = output
         self.have_test = False
 


### PR DESCRIPTION
As the built-in `file` type is deprecated in Python 3, this line causes
an error when --xml-report option is used.

Here is the error output (with Python 3.4.3):

```
$ ./test/run-test.py  --xml-report=reprt.xml
Traceback (most recent call last):
  File "./test/run-test.py", line 14, in <module>
    sys.exit(pikzie.Tester(version=pikzie.version).run())
  File "./pikzie/lib/pikzie/tester.py", line 61, in run
    listeners.append(pikzie.report.XML(xml_report))
  File "./pikzie/lib/pikzie/report.py", line 22, in __init__
    output = file(output, "w")
NameError: name 'file' is not defined
```
