### PR TITLE
Python 3: convert `target_modules` to list explicitly.

### DIFF
--- a/lib/pikzie/tester.py
+++ b/lib/pikzie/tester.py
@@ -37,7 +37,7 @@ class Tester(object):
                     return sys.modules[module_or_name]
                 else:
                     return module_or_name
-            target_modules = map(ensure_module, target_modules)
+            target_modules = list(map(ensure_module, target_modules))
         self.target_modules = target_modules
 
     def run(self, args=None):


### PR DESCRIPTION
The TestLoader class assumes the `target_modules` attribute is a list.
However, in Python 3, the built-in map function will return an iterator
(not list).

This causes an error when each test module is executed directly with
Python 3.

For the reference, here is an actual error output with Python 3.4.2:

```
$ python test/test_utils.py
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "./pikzie/lib/pikzie/tester.py", line 107, in auto_test_run
    sys.exit(Tester(target_modules=['__main__']).run())
  File "./pikzie/lib/pikzie/tester.py", line 57, in run
    test = TestLoader(**test_suite_create_options).create_test_suite(args)
  File "./pikzie/lib/pikzie/core.py", line 547, in create_test_suite
    for test_case in self.collect_test_cases(files):
  File "./pikzie/lib/pikzie/core.py", line 528, in collect_test_cases
    for module in self._load_modules(files):
  File "./pikzie/lib/pikzie/core.py", line 581, in _load_modules
    modules = self.target_modules[:]
TypeError: 'map' object is not subscriptable
```
