### PR TITLE
Fix: call the correct handler on KeyboardInterrupt.

### DIFF
--- a/lib/pikzie/core.py
+++ b/lib/pikzie/core.py
@@ -281,7 +281,7 @@ class TestCase(TestCaseTemplate, Assertions):
                 except OmissionTestError:
                     self._omit_test(context)
                 except KeyboardInterrupt:
-                    context.interrupted()
+                    context.interrupt()
                     return
                 except:
                     self._add_error(context)
@@ -297,7 +297,7 @@ class TestCase(TestCaseTemplate, Assertions):
                 except OmissionTestError:
                     self._omit_test(context)
                 except KeyboardInterrupt:
-                    context.interrupted()
+                    context.interrupt()
                     return
                 except:
                     self._add_error(context)
@@ -309,7 +309,7 @@ class TestCase(TestCaseTemplate, Assertions):
                 except OmissionTestError:
                     self._omit_test(context)
                 except KeyboardInterrupt:
-                    context.interrupted()
+                    context.interrupt()
                 except:
                     self._add_error(context)
                     success = False


### PR DESCRIPTION
Currently, hitting ^C while testing causes an unexpected TypeError
and the runner fails to mark the 'interrupted' status flag.

This is just because `context.interrupted` is called (which is a
boolean property) rather than `context.interrupt()`.

For reference, here is the related lines of the `TestRunnerContext`
class:

``` python
class TestRunnerContext(object):
    ...
    def interrupt(self):
        "Indicates that the tests should be interrupted"
        self.interrupted = True

    def need_interrupt(self):
        return self.interrupted
```
