### PR TITLE
Notify the KeyboardInterupt to the parent context.

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -74,6 +74,9 @@ class Assertions(object):
         for test_name in tests:
             self.TestCase(test_name).run(context)
 
+            if context.need_interrupt():
+                raise KeyboardInterrupt
+
         self.assert_equal(self.RegexpMatchResult(succeeded,
                                                  (n_tests,
                                                   n_assertions,


### PR DESCRIPTION
As assert_result() creates a separate context to run the target
test case, any keyboard interruption occurred within the context
gets "swallowed" up and fails to stop the main test runner.

Fix this by raising a KeyboardInterrupt manually if SIGINT is
detected by the child context.
