### PR TITLE
Make TestCaseRunner notice the keyboard interruption.

### DIFF
--- a/lib/pikzie/core.py
+++ b/lib/pikzie/core.py
@@ -126,6 +126,8 @@ class TestCaseRunner(object):
         context.on_start_test_case(self.test_case)
         for test in tests:
             test.run(context)
+            if context.need_interrupt():
+                break
         context.on_finish_test_case(self.test_case)
 
 class TestCaseTemplate(object):


### PR DESCRIPTION
Even interrupted by keyboard, TestCaseRunner will keep working
on its test queue. This is the reason why we sometimes see some
'overrun':

```
$ ./test/run-test.py
..................P..^C...
```

(In this example above, three tests were consumed _after_ the
interruption signal is received)

This patch makes TestCaseRunner behave nicer, with respecting the
user initiated interruption.
