### PR TITLE
console ui: improve the auto color detection, part 1/2

### DIFF
--- a/lib/pikzie/ui/console.py
+++ b/lib/pikzie/ui/console.py
@@ -290,10 +290,7 @@ class ConsoleTestRunner(object):
 
     def _detect_color_availability(self):
         term = os.getenv("TERM")
-        if term and (term.endswith("term") or
-                     term.endswith("term-color") or
-                     term.endswith("term-256color") or
-                     term == "screen"):
+        if term and term != "dumb":
             return True
         emacs = os.getenv("EMACS")
         if emacs and (emacs == "t"):


### PR DESCRIPTION
The current logic fails to detect color support in a number of
environments (notably it fails with rxvt families and tmux).

Since almost all terminals support (at least some) coloring nowadays,
it's fairly reasonable to enable color output unless it is a 'dumb' terminal.

In fact, this is exactly how many programs handle the $TERM variable.
For example, Git handles it as follows (from git/color.c) :

``` c
static int check_auto_color(void)
{
    if (color_stdout_is_tty < 0)
        color_stdout_is_tty = isatty(1);
    if (color_stdout_is_tty || (pager_in_use() && pager_use_color)) {
        char *term = getenv("TERM");
        if (term && strcmp(term, "dumb"))
            return 1;
    }
    return 0;
}
```

This patch applies the change described above to the `ConsoleTestRunner` class.
