### PR TITLE
sorted(): remove an old work-around.

### DIFF
--- a/lib/pikzie/__init__.py
+++ b/lib/pikzie/__init__.py
@@ -15,20 +15,6 @@
 
 version = "1.0.3"
 
-try:
-    import __builtin__
-except ImportError:
-    pass
-else:
-    if not hasattr(__builtin__, "sorted"):
-        def sorted(iterable, cmd=None, key=None, reverse=False):
-            list = iterable[:]
-            list.sort(cmd)
-            if reverse:
-                list.reverse()
-                return list
-        __builtin__.sorted = sorted
-
 from pikzie.tester import Tester
 from pikzie.core import *
 from pikzie.decorators import *


### PR DESCRIPTION
The fallback `sorted()` function is currently broken in a number of ways:
1. When the 'reverse' parameter is `False`, `None` is returned.
2. The 'key' parameter just gets ignored.  
   (Although the parameter is in fact used by ui/console.py)
3. `TypeError` is raised if 'iterable' is an iterator.
4. The parameter schema is not compatible with the built-in one.

Since the `sorted()` builtin was introduced in Python 2.4, and now
Pikzie supports only Python 2.6 (or later), it does not seem to
make much sense to keep this work-around.
