### PR TITLE
Fix: report the number of assertions correctly.

### DIFF
--- a/lib/pikzie/assertions.py
+++ b/lib/pikzie/assertions.py
@@ -485,7 +485,7 @@ class Assertions(object):
           self.assert_exists("/tmp/nonexistence") # => fail
         """
         if os.path.exists(path):
-            self._pass_assertion
+            self._pass_assertion()
         else:
             self.fail("expected: <%s> exists" % path)
 
@@ -499,7 +499,7 @@ class Assertions(object):
         if os.path.exists(path):
             self.fail("expected: <%s> doesn't exists" % path)
         else:
-            self._pass_assertion
+            self._pass_assertion()
 
     def assert_open_file(self, name, *args):
         """
@@ -519,7 +519,7 @@ class Assertions(object):
                  pp.format_exception_class(exception_class),
                  str(exception_value))
             self._fail(message)
-        self._pass_assertion
+        self._pass_assertion()
         return result
 
     def assert_try_call(self, timeout, interval,
@@ -559,7 +559,7 @@ class Assertions(object):
                 if wait_time > 0:
                     time.sleep(wait_time)
                 rest -= max(runtime, interval)
-        self._pass_assertion
+        self._pass_assertion()
         return result
 
     def assert_kernel_symbol(self, name):
@@ -580,6 +580,6 @@ class Assertions(object):
             address = symbol_info[0]
             symbol_name = symbol_info[2]
             if name == symbol_name:
-                self._pass_assertion
+                self._pass_assertion()
                 return address
         self._fail("expected: <%r> is in kernel symbols" % name)

--- a/test/test_assertions.py
+++ b/test/test_assertions.py
@@ -578,7 +578,7 @@ class TestAssertions(pikzie.TestCase, test.utils.Assertions):
                            ["test_assert_search_syslog_call"])
 
     def test_assert_exists(self):
-        self.assert_result(False, 1, 0, 1, 0, 0, 0, 0,
+        self.assert_result(False, 1, 1, 1, 0, 0, 0, 0,
                            [('F',
                              "TestCase.test_assert_exists",
                              "expected: <%s> exists" % nonexistent_path,
@@ -586,7 +586,7 @@ class TestAssertions(pikzie.TestCase, test.utils.Assertions):
                            ["test_assert_exists"])
 
     def test_assert_not_exists(self):
-        self.assert_result(False, 1, 0, 1, 0, 0, 0, 0,
+        self.assert_result(False, 1, 1, 1, 0, 0, 0, 0,
                            [('F',
                              "TestCase.test_assert_not_exists",
                              "expected: <%s> doesn't exists" % __file__,
@@ -595,7 +595,7 @@ class TestAssertions(pikzie.TestCase, test.utils.Assertions):
 
     def test_assert_open_file(self):
         file_not_found_error = getattr(builtins, "FileNotFoundError", IOError)
-        self.assert_result(False, 1, 2, 1, 0, 0, 0, 0,
+        self.assert_result(False, 1, 4, 1, 0, 0, 0, 0,
                            [('F',
                              "TestCase.test_assert_open_file",
                              "expected: open('%s') succeeds\n"
@@ -608,7 +608,7 @@ class TestAssertions(pikzie.TestCase, test.utils.Assertions):
                            ["test_assert_open_file"])
 
     def test_try_call(self):
-        self.assert_result(False, 1, 1, 1, 0, 0, 0, 0,
+        self.assert_result(False, 1, 2, 1, 0, 0, 0, 0,
                            [('F',
                              "TestCase.test_assert_try_call",
                              "expected: %s succeeds\n"
@@ -627,7 +627,7 @@ class TestAssertions(pikzie.TestCase, test.utils.Assertions):
             self.omit("only for Linux environment")
         if not os.path.exists("/proc/kallsyms"):
             self.omit("require /proc/kallsyms")
-        self.assert_result(False, 1, 1, 1, 0, 0, 0, 0,
+        self.assert_result(False, 1, 4, 1, 0, 0, 0, 0,
                            [('F',
                              "TestCase.test_assert_kernel_symbol",
                              "expected: <'nonexistent'> is in kernel symbols",


### PR DESCRIPTION
The assert_\* methods are supposed to call `pass_assertion()` on
success, but some of them fail to do so. As a result, the total
number of assertions reported by the test process can be incorrect.

This patch fixes these methods and (also) their test cases.

**Note: How to reproduce this issue**

As an example, running the test cases for pikzie/utils.py will
report that only one assertion has been executed:

```
$ ./test/run-test.py -t test_utils
...
Finished in 0.004 seconds

3 test(s), 1 assertion(s), 0 failure(s), 0 error(s),
0 pending(s), 0 omission(s), 0 notification(s)
```

... while we actually find 10 assertions there:

```
$ grep assert_ test/test_utils.py | wc -l
10
```
