### PR TITLE
Fix: '--color=[yes|true]' does not enable coloring output.

### DIFF
--- a/lib/pikzie/ui/console.py
+++ b/lib/pikzie/ui/console.py
@@ -34,7 +34,7 @@ class ConsoleTestRunner(object):
         available_values = "[yes|true|no|false|auto]"
         def store_use_color(option, opt, value, parser):
             if value == "yes" or value == "true":
-                parser.values.verbose_level = True
+                parser.values.use_color = True
             elif value == "no" or value == "false":
                 parser.values.use_color = False
             elif value == "auto" or value is None:


### PR DESCRIPTION
The `store_use_color()` callback has a bug that it tries to set
"verbose_level" (insted of "use_color") when the color option
is set true. Because of this, we cannot enable color output
with --color=yes (or --color=true).

This patch should fix the issue.
