### PR TITLE
Add an altenative color scheme: 'simple'

### DIFF
--- a/lib/pikzie/color.py
+++ b/lib/pikzie/color.py
@@ -101,5 +101,17 @@ SCHEMES = {
         "file-name": COLORS["cyan"],
         "line-number": COLORS["yellow"],
         "content": None,
+        },
+    "simple": {
+        "success": Color("green"),
+        "notification": Color("none", bold=True),
+        "pending": Color("magenta"),
+        "omission": Color("blue"),
+        "failure": Color("red"),
+        "error": Color("yellow"),
+        "test-case-name": Color("none", bold=True),
+        "file-name": None,
+        "line-number": None,
+        "content": None,
         }
     }


### PR DESCRIPTION
This patch adds 'simple' color scheme, of which focus is on using fewer
colors and textual effects (e.g. bold font).

Although the default coloring is fairly fancy, this new schema should
retain the readability well among a wide variety of environments.
### Screenshot

Here is a comparison of how it looks like:

_--color-scheme=simple_

![simple_20160807](https://cloud.githubusercontent.com/assets/8974561/17578817/1f97a3a8-5fc9-11e6-84e1-c6822fecda70.png)

_--color-schema=default_

![default_20160807](https://cloud.githubusercontent.com/assets/8974561/17578814/15de72e2-5fc9-11e6-8f10-69730ad71da9.png)
