### PR TITLE
README.rst: add missing documentation for command-line options.

### DIFF
--- a/README.ja.rst
+++ b/README.ja.rst
@@ -318,6 +318,22 @@ Pikzieにオプションを指定する方法はこのドキュメント内の�
 
 --version                バージョンを表示して終了します。
 
+-h, --help               ヘルプメッセージを表示して終了します。
+
+--base-dir=DIR           テストファイルが含まれるルートディレクトリを
+                         指定します。テストケースをロードする際にはDIR
+                         以下が探索されます。
+
+                         デフォルトではテストスクリプト(run-test.py)が
+                         配置されたディレクトリが探索されます。
+
+--ignore-direcotry=DIRECOTRY テストケースを探索する際にDIRECTORY以下を
+                             無視します。このオプションは複数回指定する
+                             ことができます。
+
+                             デフォルトは.svn, CVS, .git, .test-result
+                             です。
+
 -pPATTERN, --test-file-name-pattern=PATTERN テストファイル名
                                             にマッチするグロ
                                             ブパターンを指定

--- a/README.rst
+++ b/README.rst
@@ -315,6 +315,20 @@ See "Template" section in this document how to pass options to Pikzie.
 
 --version               shows its own version and exits.
 
+-h, --help              shows help message and exits.
+
+--base-dir=DIR          specifies the root directory which contains
+                        the test files. Pikzie will walk inside the
+                        directory to discover test cases.
+
+                        By default, the directory contains the test
+                        runner script (run-test.py) will be used.
+
+--ignore-direcotry=DIRECOTRY Don't load tests under DIRECTORY. This
+                             option can be specified multiple times.
+
+                             Default: .svn, CVS, .git, .test-result
+
 -pPATTERN, --test-file-name-pattern=PATTERN collects test
                                             files that
                                             matches with the


### PR DESCRIPTION
While reading README.rst, I found that several command-line options
were missing from there. So write the documentation (in both English
and Japanese) for these options.

Note that usage strings for each option (like `--base-dir=DIR`) are
copied from the command-line help message.
