### PR TITLE
Fix typo of README

### DIFF
--- a/README.ja.rst
+++ b/README.ja.rst
@@ -327,7 +327,7 @@ Pikzieにオプションを指定する方法はこのドキュメント内の�
                          デフォルトではテストスクリプト(run-test.py)が
                          配置されたディレクトリが探索されます。
 
---ignore-direcotry=DIRECOTRY テストケースを探索する際にDIRECTORY以下を
+--ignore-directory=DIRECTORY テストケースを探索する際にDIRECTORY以下を
                              無視します。このオプションは複数回指定する
                              ことができます。
 

--- a/README.rst
+++ b/README.rst
@@ -324,7 +324,7 @@ See "Template" section in this document how to pass options to Pikzie.
                         By default, the directory contains the test
                         runner script (run-test.py) will be used.
 
---ignore-direcotry=DIRECOTRY Don't load tests under DIRECTORY. This
+--ignore-directory=DIRECTORY Don't load tests under DIRECTORY. This
                              option can be specified multiple times.
 
                              Default: .svn, CVS, .git, .test-result


### PR DESCRIPTION
--ignore-direc`ot`ry=DIREC`OT`RY ->
--ignore-direc`to`ry=DIREC`TO`RY